### PR TITLE
New input detection

### DIFF
--- a/App.Inputs.cs
+++ b/App.Inputs.cs
@@ -119,12 +119,13 @@ namespace MarvinsAIRA
 			Settings.UpdateWheelAxisList( wheelAxisList );
 		}
 
+		const int TIME_BETWEEN_LOOOK_FOR_NEW_INPUTS = 1;
 
 		private float _lookForNewInputsTimer = 0;
 		public void UpdateInputs( float deltaTime )
 		{
 			_lookForNewInputsTimer+= deltaTime;
-			if (_lookForNewInputsTimer > 1)
+			if (_lookForNewInputsTimer > TIME_BETWEEN_LOOOK_FOR_NEW_INPUTS)
 			{
 				_lookForNewInputsTimer = 0;
 				if (GetValidFFBInputCount() > FFBInputCount) //we have found a new input


### PR DESCRIPTION
A few times using the app I have started it up and started iracing up not realizing my wheel is off. Then I have discovered my wheel is off and turned it on.

I realized I had to quite the app then reload it. So iv added code to detect when a new ffb input is detected and the initialize it. This save the app needing to be restarted and improves the user experience..

EDIT: recreated this as I accidently pulling the the comment form another branch